### PR TITLE
Fix charge spam on valkyries

### DIFF
--- a/config/skills.js
+++ b/config/skills.js
@@ -3716,7 +3716,8 @@ module.exports = {
 				fixedSpeed: 1,
 				length: 550,
 				distance: 436,
-				noInterrupt: ['4-0']
+				noInterrupt: ['4-0'],
+				noRetry: true
 			},
 			10: { length: 900 },
 			11: {


### PR DESCRIPTION
Charge was spamming "You cannot use that skill at the moment.", I have no idea what I am doing tho, but it fixed.